### PR TITLE
Change base model to BaseSiteSetting for Wagtail 4

### DIFF
--- a/wagtailschemaorg/models.py
+++ b/wagtailschemaorg/models.py
@@ -1,4 +1,9 @@
-from wagtail.contrib.settings.models import BaseSetting
+from wagtail import VERSION as WAGTAIL_VERSION
+
+if WAGTAIL_VERSION >= (4, 0):
+    from wagtail.contrib.settings.models import BaseSiteSetting
+else:
+    from wagtail.contrib.settings.models import BaseSetting as BaseSiteSetting
 
 from .jsonld import ThingLD
 from .registry import SiteThingLD
@@ -19,10 +24,10 @@ class PageLDMixin(ThingLD):
         })
 
 
-class BaseLDSetting(SiteThingLD, BaseSetting):
+class BaseLDSetting(SiteThingLD, BaseSiteSetting):
     """
     A mix of :class:`~wagtailschemaorg.registry.SiteThingLD` and
-    :class:`wagtail.contrib.settings.models.BaseSetting`.
+    :class:`wagtail.contrib.settings.models.BaseSiteSetting`.
     """
     class Meta:
         abstract = True


### PR DESCRIPTION
Fixes #13

Wagtail 4.0 has deprecated `wagtail.contrib.settings.models.BaseSetting` in favour of `wagtail.contrib.settings.models.BaseSiteSetting`. This PR introduces into wagtail-schema.org a conditional import to maintain compatibility from Wagtail 2 into Wagtail 4.

Tested with local tests (`runtests.py`) and in one of my Wagtail projects with both Wagtail 3.x, Wagtail 4.0 and Wagtail 4.0.2.

It would be good to get this PR merged in readiness for the release of Wagtail 4.1 LTS in November 2022.