### PR TITLE
updated readme to include instructions for older version of wagtail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,13 +7,19 @@ Add Schema.org JSON-LD to your website
 Installing
 ==========
 
-wagtail-schema.org supports Wagtail 2.0 upwards.
+wagtail-schema.org supports Wagtail 2.15 upwards.
 
-Install using pip:
+Install for Wagtail 4.1+ using pip:
 
 .. code-block:: console
 
     $ pip install wagtail-schema.org
+
+Install for Wagtail < 4.1 using pip:
+
+.. code-block:: console
+
+    $ pip install wagtail-schema.org==4.0.0
 
 Add it to your ``INSTALLED_APPS`` to use the Django template tags:
 


### PR DESCRIPTION
This adds instructions for installing the package in older version of wagtail.   We noticed this issue when we were working on a clients project.  We really like the package but it was not working initially after following the current readme because our wagtail version was outdated.  I hope this can help anyone in the future avoid the same issue.