### PR TITLE
Support/wagtail 5.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{38,39,310}-dj{32,41}-wt{41,42,50}
-	py{38,39,310,311}-dj{42}-wt{50}
+	py{38,39,310}-dj{32}-wt{41,42,50,51}
+	py{38,39,310,311}-dj{41}-wt{41,42}
+	py{310,311}-dj{42}-wt{50,51}
 	flake8,isort,docs
 
 [gh-actions]
@@ -29,6 +30,7 @@ deps =
 	wt41: Wagtail>=4.1,<4.2
 	wt42: Wagtail>=4.2,<4.3
 	wt50: Wagtail>=5.0,<5.1
+	wt51: Wagtail>=5.1,<5.2
 	wtHEAD: Wagtail
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{38,39,310}-dj{32}-wt{41,42,50,51}
-	py{38,39,310,311}-dj{41}-wt{41,42}
-	py{310,311}-dj{42}-wt{50,51}
+	py{38,39,310}-dj{32,41}-wt{41,42,50,51}
+	py311-dj41-wt{41,42,50,51}
+	py311-dj42-wt{50,51}
 	flake8,isort,docs
 
 [gh-actions]


### PR DESCRIPTION
# Wagtail v5.1 update

I just looked over this package to check for Wagtail 5.1 compatibility and it looks like no changes are required to the package code.

I have adjusted the tox test matrix to test against Wagtail 5.1

A new release probably isn't required.