### PR TITLE
Update tox testing matrix to include Wagtail 5.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,10 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{38,39,310}-dj{32,41}-wt{41,42,50,51}
-	py311-dj41-wt{41,42,50,51}
-	py311-dj42-wt{50,51}
+	py{38,39,310}-dj{32,41}-wt{41,42,50,51,52}
+	py311-dj41-wt{41,42,50,51,52}
+	py311-dj42-wt{50,51,52}
+	py312-dj42-wt{52}
 	flake8,isort,docs
 
 [gh-actions]
@@ -13,6 +14,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+	3.12: py312
 
 [base]
 deps = jinja2>=2.11,<3.2
@@ -31,6 +33,7 @@ deps =
 	wt42: Wagtail>=4.2,<4.3
 	wt50: Wagtail>=5.0,<5.1
 	wt51: Wagtail>=5.1,<5.2
+	wt52: Wagtail>=5.2,<5.3
 	wtHEAD: Wagtail
 
 [testenv:flake8]


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

Changes:
- Update tox testing matrix to include Wagtail 5.2