### PR TITLE
Testing against Wagtail 6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repository

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5',
         'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 5',
         'Framework :: Wagtail :: 6',

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,12 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{38,39,310,311}-dj42-wt{52,60,61,62}
+	py{39,310,311}-dj42-wt{52,60,61,62}
     py{310,311,312}-dj50-wt{52,60,61,62}
 	flake8,isort,docs
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,9 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{39,310,311}-dj42-wt{52,60,61,62}
-    py{310,311,312}-dj50-wt{52,60,61,62}
+	py{39,310,311}-dj42-wt{52,60,61,62,63}
+    py{310,311,312}-dj50-wt{52,60,61,62,63}
+	py{310,311,312}-dj51-wt{63}
 	flake8,isort,docs
 
 [gh-actions]
@@ -24,11 +25,13 @@ deps =
 	{[base]deps}
 	dj42: django>=4.2,<4.3
 	dj50: django>=5.0,<5.1
+	dj51: django>=5.1,<5.2
 	djHEAD: django
 	wt52: Wagtail>=5.2,<5.3
 	wt60: Wagtail>=6.0,<6.1
 	wt61: Wagtail>=6.1,<6.2
 	wt62: Wagtail>=6.2,<6.3
+	wt63: Wagtail>=6.3,<6.4
 	wtHEAD: Wagtail
 
 [testenv:flake8]


### PR DESCRIPTION
This pull request includes changes to update the testing configurations and dependencies for the project.

Updates to testing configurations:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R18): Removed Python 3.8 from the testing matrix.
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L5-L11): Removed Python 3.8 from the environment list and added Django 5.1 and Wagtail 6.3 to the environment list.
* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R28-R34): Added dependencies for Django 5.1 and Wagtail 6.3.

Updates to dependencies:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L44): Removed Python 3.8 from the list of supported programming languages.
* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R53): Added Django 5.1 to the list of supported frameworks.

Questions:

* would there be interest to add python 3.13 as a version that test run against. Wagtail 6.3 + Django 5.1 is compatible