### PR TITLE
Wagtail 6.4 and Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 skip_missing_interpreters = True
 
 envlist =
-	py{39,310,311}-dj42-wt{52,60,61,62,63}
-    py{310,311,312}-dj50-wt{52,60,61,62,63}
-	py{310,311,312}-dj51-wt{63}
+	py{39,310,311}-dj42-wt{52,60,61,62,63,64}
+    py{310,311,312}-dj50-wt{52,60,61,62,63,64}
+	py{310,311,312}-dj51-wt{63,64}
 	flake8,isort,docs
 
 [gh-actions]
@@ -13,6 +13,7 @@ python =
     3.10: py310
     3.11: py311
 	3.12: py312
+	3.13: py313
 
 [base]
 deps = jinja2>=2.11,<3.2
@@ -32,6 +33,7 @@ deps =
 	wt61: Wagtail>=6.1,<6.2
 	wt62: Wagtail>=6.2,<6.3
 	wt63: Wagtail>=6.3,<6.4
+	wt64: Wagtail>=6.4,<6.5
 	wtHEAD: Wagtail
 
 [testenv:flake8]


### PR DESCRIPTION
This pull request includes updates to the testing configurations to support new versions of Python and Wagtail. 

Updates to testing configurations:

* Added Python 3.13 to the testing matrix.
* Added Python 3.13 to the `python` versions and updated the `envlist` to include Wagtail 6.4 for various Django versions.